### PR TITLE
ℹ️ fixed vigenere to handle non-ASCII letters

### DIFF
--- a/chepy/modules/encryptionencoding.py
+++ b/chepy/modules/encryptionencoding.py
@@ -1120,7 +1120,7 @@ class EncryptionEncoding(ChepyCore):
             raise ValueError("The key must consist only of letters")  # pragma: no cover
 
         for i in range(len(input_str)):
-            if input_str[i].isalpha():
+            if input_str[i].isalpha() and input_str[i].lower() in alphabet:
                 is_upper = input_str[i].isupper()
                 input_char = input_str[i].lower()
                 key_char = key[(i - fail) % len(key)]
@@ -1162,7 +1162,7 @@ class EncryptionEncoding(ChepyCore):
             raise ValueError("The key must consist only of letters")  # pragma: no cover
 
         for i in range(len(input_str)):
-            if input_str[i].isalpha():
+            if input_str[i].isalpha() and input_str[i].lower() in alphabet:
                 is_upper = input_str[i].isupper()
                 input_char = input_str[i].lower()
                 key_char = key[(i - fail) % len(key)]

--- a/tests/test_encryptionencoding.py
+++ b/tests/test_encryptionencoding.py
@@ -669,12 +669,13 @@ def test_blowfish_decrypt():
     )
 
 
-def test_vigener_encode():
+def test_vigenere_encode():
     assert (
         Chepy("shaktictf{y4Yyy!_M1S5i0n_4cCoMpL1sH3D}").vigenere_encode("victory").o
         == b"npcdhzaon{a4Rmp!_K1N5q0p_4vQfKkT1uA3R}"
     )
     assert Chepy("secret").vigenere_encode("secret").o == b"kieiim"
+    assert Chepy("Vigenère").vigenere_encode("key").o.decode() == "Fmeorèpo"
 
 
 def test_vigenere_decode():
@@ -683,6 +684,7 @@ def test_vigenere_decode():
         == b"shaktictf{y4Yyy!_M1S5i0n_4cCoMpL1sH3D}"
     )
     assert Chepy("kieiim").vigenere_decode("secret").o == b"secret"
+    assert Chepy("Fmeorèpo").vigenere_decode("key").o.decode() == "Vigenère"
 
 
 def test_affine_encode():


### PR DESCRIPTION
Updated the vigenere encode and decode methods to only process letters present in the defined alphabet, preventing errors with non-ASCII characters. Added tests to verify correct handling of Unicode input.

<img width="1470" alt="decode vigenere" src="https://github.com/user-attachments/assets/a3574163-5a9b-4aea-8f9f-4ed9c3eb4b68" />
