### PR TITLE
union syntax fix

### DIFF
--- a/chepy/modules/encryptionencoding.py
+++ b/chepy/modules/encryptionencoding.py
@@ -2012,12 +2012,12 @@ class EncryptionEncoding(ChepyCore):
 
     @ChepyDecorators.call_stack
     def pgp_decrypt(
-        self, passphrase: Union[str | bytes], armoured: bool = False
+        self, passphrase: Union[str, bytes], armoured: bool = False
     ) -> EncryptionEncodingT:
         """Decrypt PGP encrypted file with passphrase
 
         Args:
-            passphrase (Union[str | bytes]): passphrase
+            passphrase (Union[str, bytes]): passphrase
             armoured (bool): PGP armoured format
 
         Returns:


### PR DESCRIPTION
This union syntax stops use in Python versions less than 3.10